### PR TITLE
fix: 汇率API 404 Not Found

### DIFF
--- a/app/Http/Controllers/Pay/StripeController.php
+++ b/app/Http/Controllers/Pay/StripeController.php
@@ -520,15 +520,15 @@ class StripeController extends PayController
     public function getUsdCurrency($cny)
     {
         $client = new Client();
-        $res = $client->get('https://m.cmbchina.com/api/rate/getfxrate');
+        $res = $client->get('https://fx.cmbchina.com/api/v1/fx/rate');
         $fxrate = json_decode($res->getBody(), true);
-        if (!isset($fxrate['data'])) {
+        if (!isset($fxrate['body'])) {
             throw new \Exception('汇率接口异常');
         }
         $dfFxrate = 0.13;
-        foreach ($fxrate['data'] as $item) {
-            if ($item['ZCcyNbr'] == "美元") {
-                $dfFxrate = bcdiv(100, $item['ZRtcOfr'], 2);
+        foreach ($fxrate['body'] as $item) {
+            if ($item['ccyNbr'] == "美元") {
+                $dfFxrate = bcdiv(100, $item['rtcOfr'], 2);
                 break;
             }
         }


### PR DESCRIPTION
支付网关异常！Client error: `GET https://m.cmbchina.com/api/rate/getfxrate` resulted in a `404 Not Found` response: {"timestamp":"2024-02-01T12:43:54.363+00:00","status":404,"error":"Not Found","path":"/rate/getfxrate"}